### PR TITLE
Use different Fathom site ID for previews

### DIFF
--- a/_data/fathom.js
+++ b/_data/fathom.js
@@ -1,0 +1,3 @@
+module.exports = {
+  site_id: process.env.FATHOM_SITE_ID
+};

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="{{ '/css/index.css' | url }}">
     <link rel="alternate" href="{{ metadata.feed.path | url }}" type="application/atom+xml" title="{{ metadata.title }}">
 
+  {% if fathom.site_id %}
     <script>
       (function(f, a, t, h, o, m){
       	a[h]=a[h]||function(){
@@ -18,9 +19,10 @@
       	o.async=1; o.src=t; o.id='fathom-script';
       	m.parentNode.insertBefore(o,m)
       })(document, window, '//obyford.usesfathom.com/tracker.js', 'fathom');
-      fathom('set', 'siteId', 'FSRVD');
+      fathom('set', 'siteId', '{{ fathom.site_id }}');
       fathom('trackPageview');
     </script>
+  {% endif %}
   </head>
   <body>
     <div class="wrapper">

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,7 @@
 [build]
   publish = "_site"
   command = "DEBUG=* eleventy"
+  environment = { FATHOM_SITE_ID = "HGDZCOSY" }
+
+[context.production]
+  environment = { FATHOM_SITE_ID = "FSRVD" }


### PR DESCRIPTION
This also means we avoid serving JavaScript when running the site locally, as the `FATHOM_SITE_ID` environment variable will not be set.